### PR TITLE
Expand relative paths in /// <reference path="..." /> before compile

### DIFF
--- a/lib/typescript/rails/template_handler.rb
+++ b/lib/typescript/rails/template_handler.rb
@@ -41,7 +41,8 @@ module Typescript
       end
 
       def evaluate(scope, locals, &block)
-        @output ||= TypeScript::Node.compile(data)
+        source = Typescript::Rails.replace_relative_references(file, data)
+        @output ||= TypeScript::Node.compile(source)
       end
 
       def allows_script?
@@ -57,8 +58,26 @@ module Typescript
 
       def self.call(template)
         compiled_source = erb_handler.call(template)
-        "TypeScript::Node.compile(begin;#{compiled_source};end)"
+        escaped_path = template.identifier.gsub(/['\\]/, '\\\\\&') # "'" => "\\'", '\\' => '\\\\'
+        <<-EOS
+        TypeScript::Node.compile(
+          Typescript::Rails.replace_relative_references(
+            '#{escaped_path}', (begin;#{compiled_source};end)
+          )
+        )
+        EOS
       end
+    end
+
+    # Replace relative paths specified in /// <reference path="..." /> with absolute paths.
+    #
+    # @param [String] ts_path Source .ts path
+    # @param [String] ts source. It might be pre-processed by erb.
+    # @return [String] replaces source
+    def self.replace_relative_references(ts_path, source)
+      ts_dir = File.dirname(File.expand_path(ts_path))
+      escaped_dir = ts_dir.gsub(/["\\]/, '\\\\\&') # "\"" => "\\\"", '\\' => '\\\\'
+      source.gsub(%r!(^///\s*<reference\s+path=")([^/"][^"]+)("\s*/>)!, '\1' + File.join(escaped_dir, '\2') + '\3')
     end
   end
 end

--- a/test/support/site/ref1_2.js.ts
+++ b/test/support/site/ref1_2.js.ts
@@ -1,3 +1,3 @@
-/// <reference path="<%= File.join(File.dirname(__FILE__), "ref1_1.js.ts") %>" />
+/// <reference path="ref1_1.js.ts" />
 
 f(1, 2)

--- a/test/support/site/ref2_2.js.ts
+++ b/test/support/site/ref2_2.js.ts
@@ -1,3 +1,3 @@
-/// <reference path="<%= File.join(File.dirname(__FILE__), "ref2_1.d.ts") %>" />
+/// <reference path="./ref2_1.d.ts" />
 
 f(1, 2)


### PR DESCRIPTION
Now users doesn't need to use File.dirname(**FILE**) for <reference />.
