### PR TITLE
Update template_handler.rb

### DIFF
--- a/lib/typescript/rails/template_handler.rb
+++ b/lib/typescript/rails/template_handler.rb
@@ -77,7 +77,9 @@ module Typescript
     def self.replace_relative_references(ts_path, source)
       ts_dir = File.dirname(File.expand_path(ts_path))
       escaped_dir = ts_dir.gsub(/["\\]/, '\\\\\&') # "\"" => "\\\"", '\\' => '\\\\'
-      source.gsub(%r!(^///\s*<reference\s+path=")([^/"][^"]+)("\s*/>)!, '\1' + File.join(escaped_dir, '\2') + '\3')
+      source.gsub(%r!(^///\s*<reference\s+path=")([^/"][^"]+)("\s*/>)!) do
+        $1 + Pathname.new(escaped_dir).join($2).to_s + $3
+      end
     end
   end
 end


### PR DESCRIPTION
jRuby seems to have some issues with providing captures to function calls within the second argument of gsub, switching the replacement procedure to a block solved the issue. Also used the Pathname object to return a clean absolute path.
