### PR TITLE
Fixes

### DIFF
--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -17,16 +17,13 @@ module Typescript::Rails::Compiler
 
       # Why don't we just use gsub? Because it display odd behavior with File.join on Ruby 2.0
       # So we go the long way around.
-      output = []
-      source.each_line do |l|
+      source.each_line.map { |l|
         if l.starts_with?('///') && !(m = %r!^///\s*<reference\s+path="([^"]+)"\s*/>\s*!.match(l)).nil?
-          output << l.sub(m.captures[0], File.join(escaped_dir, m.captures[0]))
+          l.sub(m.captures[0], File.join(escaped_dir, m.captures[0]))
         else
-          output << l
+          l
         end
-      end
-
-      output.join('')
+      }.join
     end
 
     # @param [String] ts_path

--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -17,15 +17,16 @@ module Typescript::Rails::Compiler
 
       # Why don't we just use gsub? Because it display odd behavior with File.join on Ruby 2.0
       # So we go the long way around.
-      output = ''
+      output = []
       source.each_line do |l|
         if l.starts_with?('///') && !(m = %r!^///\s*<reference\s+path="([^"]+)"\s*/>\s*!.match(l)).nil?
-          l = l.sub(m.captures[0], File.join(escaped_dir, m.captures[0]))
+          output << l.sub(m.captures[0], File.join(escaped_dir, m.captures[0]))
+        else
+          output << l
         end
-        output = output + l + $/
       end
 
-      output
+      output.join('')
     end
 
     # @param [String] ts_path

--- a/lib/typescript/rails/template.rb
+++ b/lib/typescript/rails/template.rb
@@ -22,7 +22,19 @@ class Typescript::Rails::Template < ::Tilt::Template
   end
 
   def evaluate(scope, locals, &block)
+    begin
     @output ||= ::Typescript::Rails::Compiler.compile(file, data)
+    
+    # This is hacky as hell but it works for now
+    rescue RuntimeError => e
+      if e.message =~ /error\sTS\d+:\s/ # Got TypeScript error (probably)?
+        # Replace path to tempfile in error with path to asset file
+        # TODO: Fix hacky regexp
+        raise RuntimeError, e.message.gsub(/^\/.*\.ts\(/, "#{file}(")
+      else
+        raise e
+      end
+    end
   end
 
   # @override


### PR DESCRIPTION
* Fixes a bug in `replace_relative_references` that was adding `\n\n` for every `\n` in the original source, which in turn was causing line numbers displayed in errors to be meaningless.

* Make errors show the path to the asset file as opposed to the compilers tempfile.  This is a kludge, but it works.

* No new tests, but no failing tests.