### PR TITLE
use `any` type

### DIFF
--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -39,7 +39,6 @@ module Typescript::Rails::Compiler
   end
 
   self.default_options = [
-      '--target', 'ES5',
-      '--noImplicitAny'
+      '--target', 'ES5'
   ]
 end


### PR DESCRIPTION
Hi

I think that you use `any` in TypeScript is not good, but I want to use `any` type. 
Would not get to be able to use the `any` type by default.

Regards

<hr>

はじめまして。

TypeScriptで`any`を使うことはあまり良くないと思いますが、使わなくてはならない場面が出てきたりします。デフォルトで`any`を使えるようにしてもらえないでしょうか？

よろしくお願いします。
