### PR TITLE
Remove extra newline that was causing incorrect line numbers in error messages

### DIFF
--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -22,7 +22,7 @@ module Typescript::Rails::Compiler
         if l.starts_with?('///') && !(m = %r!^///\s*<reference\s+path="([^"]+)"\s*/>\s*!.match(l)).nil?
           l = l.sub(m.captures[0], File.join(escaped_dir, m.captures[0]))
         end
-        output = output + l + $/
+        output = output + l
       end
 
       output


### PR DESCRIPTION
The `l` variable already has the newline from the input. No need to add it explicitly.
