### PR TITLE
expire root TS cache in response to change in referenced `.ts` files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 
 group :test do
   gem 'rails', '~> 4.0'
+  gem 'sprockets-rails', '> 2.0'
   gem 'minitest-power_assert'
   gem 'coveralls'
   gem 'simplecov'

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Configurations:
 Typescript::Rails::Compiler.default_options = [ ... ]
 ```
 
+## Referenced TypeScript dependencies
+
+`typescript-rails` recurses through all [TypeScript-style](https://github.com/teppeis/typescript-spec-md/blob/master/en/ch11.md#1111-source-files-dependencies) referenced files and tells its [`Sprockets::Context`](https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/context.rb) that the TS file being processed [`depend`s`_on`](https://github.com/sstephenson/sprockets#the-depend_on-directive) each file listed as a reference. This activates Sprocket’s cache-invalidation behavior when any of the descendant references of the root TS file is changed.
 
 ## Contributing
 

--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -18,8 +18,9 @@ module Typescript::Rails::Compiler
       # Why don't we just use gsub? Because it display odd behavior with File.join on Ruby 2.0
       # So we go the long way around.
       output = (source.each_line.map do |l|
-        if l.starts_with?('///') && !(m = %r!^///\s*<reference\s+path="([^"]+)"\s*/>\s*!.match(l)).nil?
-          l = l.sub(m.captures[0], File.join(escaped_dir, m.captures[0]))
+        if l.starts_with?('///') && !(m = %r!^///\s*<reference\s+path=(?:"([^"]+)"|'([^']+)')\s*/>\s*!.match(l)).nil?
+          matched_path = m.captures.compact[0]
+          l = l.sub(matched_path, File.join(escaped_dir, matched_path))
         end
         next l
       end).join

--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -28,10 +28,36 @@ module Typescript::Rails::Compiler
       output
     end
 
+    # Get all references
+    #
+    # @param [String] path Source .ts path
+    # @param [String] source. It might be pre-processed by erb.
+    # @yieldreturn [String] matched ref abs_path
+    def get_all_reference_paths(path, source, visited_paths=Set.new, &block)
+      visited_paths << path
+      source ||= File.read(path)
+      source.each_line do |l|
+        if l.starts_with?('///') && !(m = %r!^///\s*<reference\s+path=(?:"([^"]+)"|'([^']+)')\s*/>\s*!.match(l)).nil?
+          matched_path = m.captures.compact[0]
+          abs_matched_path = File.expand_path(matched_path, File.dirname(path))
+          unless visited_paths.include? abs_matched_path
+            block.call abs_matched_path
+            get_all_reference_paths(abs_matched_path, nil, visited_paths, &block)
+          end
+        end
+      end
+    end
+
     # @param [String] ts_path
     # @param [String] source TypeScript source code
+    # @param [Sprockets::Context] sprockets context object
     # @return [String] compiled JavaScript source code
-    def compile(ts_path, source, *options)
+    def compile(ts_path, source, context=nil, *options)
+      if context
+        get_all_reference_paths(File.expand_path(ts_path), source) do |abs_path|
+          context.depend_on abs_path
+        end
+      end
       s = replace_relative_references(ts_path, source)
       ::TypeScript::Node.compile(s, *default_options, *options)
     end

--- a/lib/typescript/rails/template.rb
+++ b/lib/typescript/rails/template.rb
@@ -21,8 +21,8 @@ class Typescript::Rails::Template < ::Tilt::Template
     end
   end
 
-  def evaluate(scope, locals, &block)
-    @output ||= ::Typescript::Rails::Compiler.compile(file, data)
+  def evaluate(context, locals, &block)
+    @output ||= ::Typescript::Rails::Compiler.compile(file, data, context)
   end
 
   # @override

--- a/test/assets_test.rb
+++ b/test/assets_test.rb
@@ -42,6 +42,7 @@ class AssetsTest < ActiveSupport::TestCase
 
   test "assets .js.ts is compiled from TypeScript to JavaScript" do
     assert { assets["javascripts/hello"].present? }
+    assert { assets["javascripts/hello"].send(:dependency_paths).map(&:pathname).map(&:to_s).include? File.expand_path("#{File.dirname(__FILE__)}/fixtures/assets/javascripts/included.ts") }
     assert { assets["javascripts/hello"].body.include?('var s = "Hello, world!";') }
   end
 end

--- a/test/fixtures/assets/javascripts/hello.js.ts
+++ b/test/fixtures/assets/javascripts/hello.js.ts
@@ -1,2 +1,3 @@
+/// <reference path="reference.ts" />
 var s: string = "Hello, world!";
-console.log(s)
+log_to_console(s);

--- a/test/fixtures/assets/javascripts/included.ts
+++ b/test/fixtures/assets/javascripts/included.ts
@@ -1,0 +1,4 @@
+/// <reference path="reference.ts" />
+var log_to_console = function(x: string): void {
+  console.log(x)
+}

--- a/test/fixtures/assets/javascripts/reference.ts
+++ b/test/fixtures/assets/javascripts/reference.ts
@@ -1,0 +1,2 @@
+/// <reference path="hello.js.ts" />
+/// <reference path="included.ts" />


### PR DESCRIPTION
This PR is intended to fix the undesirable behavior described in issue #23 by the approach I propose there. See that issue for context.

Here, I introduce a step into the TS compiler wrapper that recurses through all referenced files and tells its [`Sprockets::Context`](https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/context.rb) that the TS file being processed [`depend`s`_on`](https://github.com/sstephenson/sprockets#the-depend_on-directive) each file listed as a reference in the TS idiom.

I may have overlooked an easy fix, and Ruby’s not my native language, so feel free to suggest stylistic or other changes! I’m eager to help, and solve our local dev env woes for good. Thanks.

Will