### PR TITLE
Add Tsx Support

### DIFF
--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -58,7 +58,8 @@ module Typescript::Rails::Compiler
       end
       s = replace_relative_references(ts_path, source)
       begin
-        ::TypeScript::Node.compile(s, *default_options, *options)
+        extension = File.extname(ts_path)
+        ::TypeScript::Node.compile(s, extension, *default_options, *options)
       rescue Exception => e
         raise "Typescript error in file '#{ts_path}':\n#{e.message}"
       end

--- a/lib/typescript/rails/railtie.rb
+++ b/lib/typescript/rails/railtie.rb
@@ -6,6 +6,7 @@ class Typescript::Rails::Railtie < ::Rails::Railtie
       require 'typescript/rails/template'
       require 'sprockets'
       Sprockets.register_engine '.ts', Typescript::Rails::Template
+      Sprockets.register_engine '.tsx', Typescript::Rails::Template
     end
   end
 end

--- a/lib/typescript/rails/template_handler.rb
+++ b/lib/typescript/rails/template_handler.rb
@@ -18,4 +18,5 @@ end
 
 ActiveSupport.on_load(:action_view) do
   ActionView::Template.register_template_handler :ts, Typescript::Rails::TemplateHandler
+  ActionView::Template.register_template_handler :tsx, Typescript::Rails::TemplateHandler
 end


### PR DESCRIPTION
This pull request adds `tsx` support to this gem. The `tsx` file extension is used by typescript to signify that the file contains JSX syntax and to compile accordingly. The merge of this depends on https://github.com/typescript-ruby/typescript-node-ruby/pull/11 being merged first.
