### PR TITLE
Add typescript template generator (not defaulted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ Configurations:
 Typescript::Rails::Compiler.default_options = [ ... ]
 ```
 
+## Default Javascript Compilation
+
+Add this line to your `config/application.rb` as show below, above the `config.assets.enabled = true`:
+
+```ruby
+config.app_generators.javascript_engine :typescript
+
+# Enable the asset pipeline
+config.assets.enabled = true
+```
+
+If you don't want it to be the default javascript engine, you can also use it adhoc as show below:
+
+```ruby
+rails g controller MyController --javascript_engine=typescript
+```
+
 ## Referenced TypeScript dependencies
 
 `typescript-rails` recurses through all [TypeScript-style](https://github.com/teppeis/typescript-spec-md/blob/master/en/ch11.md#1111-source-files-dependencies) referenced files and tells its [`Sprockets::Context`](https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/context.rb) that the TS file being processed [`depend`s`_on`](https://github.com/sstephenson/sprockets#the-depend_on-directive) each file listed as a reference. This activates Sprocket’s cache-invalidation behavior when any of the descendant references of the root TS file is changed.

--- a/lib/rails/generators/typescript/assets/assets_generator.rb
+++ b/lib/rails/generators/typescript/assets/assets_generator.rb
@@ -1,0 +1,13 @@
+require "rails/generators/named_base"
+
+module Typescript
+  module Generators
+    class AssetsGenerator < ::Rails::Generators::NamedBase
+      source_root File.expand_path("../templates", __FILE__)
+
+      def copy_typescript
+        template "javascript.ts", File.join('app/assets/javascripts', class_path, "#{file_name}.ts")
+      end
+    end
+  end
+end

--- a/lib/rails/generators/typescript/assets/templates/javascript.ts
+++ b/lib/rails/generators/typescript/assets/templates/javascript.ts
@@ -1,0 +1,3 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.
+// You can use TypeScript in this file: www.typescriptlang.org

--- a/lib/typescript/rails/engine.rb
+++ b/lib/typescript/rails/engine.rb
@@ -1,6 +1,18 @@
 require 'rails/engine'
+require 'rails/generators'
+require 'typescript/rails/js_hook'
 
 class Typescript::Rails::Engine < Rails::Engine
-  # For now, let's not be the default generator ...
-  # config.app_generators.javascript_engine :ts
+  # To become the default generator...
+  # config.app_generators.javascript_engine :typescript
+
+  if config.respond_to?(:annotations)
+    config.annotations.register_extensions(".ts") { |annotation| /#\s*(#{annotation}):?\s*(.*)$/ }
+  end
+
+  initializer 'override js_template hook' do |app|
+    if app.config.generators.rails[:javascript_engine] == :typescript
+      ::Rails::Generators::NamedBase.send :include, Typescript::Rails::JsHook
+    end
+  end
 end

--- a/lib/typescript/rails/js_hook.rb
+++ b/lib/typescript/rails/js_hook.rb
@@ -1,0 +1,15 @@
+module Typescript
+  module Rails
+    module JsHook
+      extend ActiveSupport::Concern
+
+      included do
+        no_tasks do
+          redefine_method :js_template do |source, destination|
+            template(source + '.ts', destination + '.ts')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/typescript/rails/version.rb
+++ b/lib/typescript/rails/version.rb
@@ -1,5 +1,5 @@
 module Typescript
   module Rails
-    VERSION = '0.6.2.3'
+    VERSION = '0.6.2.4'
   end
 end

--- a/test/assets_generator_test.rb
+++ b/test/assets_generator_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+require 'rails/generators/typescript/assets/assets_generator'
+
+class AssetGeneratorTest < Rails::Generators::TestCase
+  tests Typescript::Generators::AssetsGenerator
+
+  destination File.expand_path("../tmp", __FILE__)
+  setup :prepare_destination
+
+  def test_assets
+    run_generator %w(posts)
+    assert_no_file "app/assets/javascripts/posts.js"
+    assert_file "app/assets/javascripts/posts.ts"
+  end
+end

--- a/test/controller_generator_test.rb
+++ b/test/controller_generator_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'rails/generators/rails/controller/controller_generator'
+require 'rails/generators/typescript/assets/assets_generator'
+
+class ControllerGeneratorTest < Rails::Generators::TestCase
+  tests Rails::Generators::ControllerGenerator
+
+  destination File.expand_path("../tmp", __FILE__)
+  setup do
+    prepare_destination
+    copy_routes
+  end
+
+  def test_assets
+    run_generator %w(posts --javascript-engine=typescript --orm=false)
+    assert_no_file "app/assets/javascripts/posts.js"
+    assert_file "app/assets/javascripts/posts.ts"
+  end
+end

--- a/test/scaffold_generator_test.rb
+++ b/test/scaffold_generator_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'rails/generators/rails/scaffold/scaffold_generator'
+require 'rails/generators/typescript/assets/assets_generator'
+
+class ScaffoldGeneratorTest < Rails::Generators::TestCase
+  tests Rails::Generators::ScaffoldGenerator
+
+  destination File.expand_path("../tmp", __FILE__)
+  setup do
+    prepare_destination
+    copy_routes
+  end
+
+  def test_assets
+    run_generator %w(posts --javascript-engine=typescript --orm=false)
+    assert_no_file "app/assets/javascripts/posts.js"
+    assert_file "app/assets/javascripts/posts.ts"
+  end
+end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -1,0 +1,1 @@
+# routes dummy file

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,9 @@ require 'rails'
 require 'rails/test_help'
 require 'minitest-power_assert'
 
+# For generators
+require 'rails/generators/test_case'
+
 def copy_routes
   routes = File.expand_path('../support/routes.rb', __FILE__)
   destination = File.join(destination_root, 'config')


### PR DESCRIPTION
Adds all of the plumbing to support a .ts file template generator. In the spirit of maintiaining existing functionality, we do not default the default javascript generator to typescript. However, anyone can opt into this functionality by adding the following to their `config/application.rb`:
```ruby
config.generators do |g|
  g.javascript_engine :typescript
end
```